### PR TITLE
Feature: Add Custom Subtitles from Local Drive

### DIFF
--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -95,8 +95,9 @@ var Player = function() {
 
 	    video.mediaelementplayer({
 			videoVolume: 'horizontal',
-			features: ['playpause','current','progress','duration','fullscreen','volume','tracks','torrentinfo','fontawesome'],
+			features: ['playpause','current','progress','duration','fullscreen','volume','tracks','torrentinfo','fontawesome', 'customtracks'],
 			success : function(mediaElement, domObject, player) {
+        t.mePlayer = player;
 				// $(mediaElement).on('ended', function(){
 				// }).on('loadeddata',function() {
 				// });

--- a/assets/js/vendor/7.4.mejs-feature-customtracks.js
+++ b/assets/js/vendor/7.4.mejs-feature-customtracks.js
@@ -1,0 +1,45 @@
+(function($) {
+
+  $.extend(MediaElementPlayer.prototype, {
+
+    buildcustomtracks: function(player, controls, layers, media) {
+      var t = this
+
+      // Check if 'tracks'
+      if (!t.captionsButton) return
+
+      // Add custom track button
+      t.captionsButton.find('div.arrow').before(
+        $('<div class="head">Custom</div>')
+      )
+
+
+      // Debugging purposes
+      setTimeout(function() {
+        t.addTextTrack('test2.srt');
+      }, 1000)
+
+    },
+
+    addTextTrack: function (src, kind) {
+      var t = this
+
+      var track = {
+        kind:     (kind || 'subtitles'),
+        src:      src,
+        isLoaded: false,
+        default:  true,
+        label:    'Custom Track', // TODO filename
+        srclang:  'custom'
+      }
+
+      var trackId = t.tracks.push(track)-1
+
+      t.addTrackButton(track.srclang, track.label)
+
+      t.loadTrack(trackId)
+    }
+
+  })
+
+})(mejs.$);


### PR DESCRIPTION
Add local subtitles (*.srt) by dragging them into the player. (https://github.com/Cuevana/storm/issues/1)

Encoding is/will be an issue, I assume ISO-8859-1 (Spanish) -- as I seen in the rest of the app. But won't work properly with other languages. We'll need a charset detector, or maybe guess based on language.

TODO: UI Design. I added a "tip" on the subtitles menu. I think it should be styled to be smaller or maybe completely removed.
