### PR TITLE
Always show subtitles button

### DIFF
--- a/assets/js/5.1.mediaelement-and-player.js
+++ b/assets/js/5.1.mediaelement-and-player.js
@@ -4161,8 +4161,6 @@ if (typeof jQuery != 'undefined') {
 		hasChapters: false,
 
 		buildtracks: function(player, controls, layers, media) {
-			if (player.tracks.length == 0)
-				return;
 
 			var t = this, 
 				i, 
@@ -4204,8 +4202,7 @@ if (typeof jQuery != 'undefined') {
 						'</div>'+
 					'</div>')
 						.appendTo(controls);
-			
-						
+
 			var subtitleCount = 0;
 			for (i=0; i<player.tracks.length; i++) {
 				if (player.tracks[i].kind == 'subtitles') {

--- a/assets/js/5.4.mejs-feature-customtracks.js
+++ b/assets/js/5.4.mejs-feature-customtracks.js
@@ -1,5 +1,10 @@
 (function($) {
 
+  // Modify default option to always show captions button (even if there are no subs loaded yet)
+  $.extend(mejs.MepDefaults, {
+    hideCaptionsButtonWhenEmpty: false
+  });
+
   $.extend(MediaElementPlayer.prototype, {
 
     buildcustomtracks: function(player, controls, layers, media) {
@@ -55,6 +60,7 @@
       // ensure a different srclang for each file
       track.srclang =+ t.tracks.push(track)-1 
       t.addTrackButton(track.srclang, track.label)
+      t.checkForTracks()
 
       var reader = new FileReader();
       reader.readAsText(file, charset);


### PR DESCRIPTION
Arregla un bug donde si el video no tenía subtitulos definidos con `<track>`, eliminaba completamente la funcionalidad.. anulando la posibilidad de agregar nuevos. Es un bug de mediaElement, en realidad, ya que ignora el parametro definido en las opciones. Eliminando una linea innecesaria de código se soluciona.

Además, modifiqué el plugin para que siempre muestre el botón de subtitulos por default.
