### PR TITLE
Add Mouse support for Touch & mouse devices - Update 5.1.mediaelement-and-player.js

### DIFF
--- a/app/assets/js/5.1.mediaelement-and-player.js
+++ b/app/assets/js/5.1.mediaelement-and-player.js
@@ -2450,7 +2450,35 @@ if (typeof jQuery != 'undefined') {
 								}
 							}
 						});
-
+						// show/hide controls with mouse for Touch & Mouse device
+						t.container
+							.bind('mouseenter mouseover', function () {
+								if (t.controlsEnabled) {
+									if (!t.options.alwaysShowControls) {
+										t.killControlsTimer('enter');
+										t.showControls();
+										t.startControlsTimer(2500);
+									}
+								}
+							})
+							.bind('mousemove', function() {
+								if (t.controlsEnabled) {
+									if (!t.controlsAreVisible) {
+										t.showControls();
+									}
+									//t.killControlsTimer('move');
+									if (!t.options.alwaysShowControls) {
+										t.startControlsTimer(2500);
+									}
+								}
+							})
+							.bind('mouseleave', function () {
+								if (t.controlsEnabled) {
+									if (!t.media.paused && !t.options.alwaysShowControls) {
+										t.startControlsTimer(1000);
+									}
+								}
+							});
 					} else {
 
 						// create callback here since it needs access to current


### PR DESCRIPTION
This update solve an issue that affect touch & mouse devices (as win8 computers), that dont show play/pause menu with mousemove.

This adds mousemove, mouseenter, mouseover, mousemove and mouseleave events even if you are on touch devices.

another way could be just ignore touch devices, but i use my computer with touch sometimes and with mouse  in other moments.
