### PR TITLE
Fit video to screen plugin.

### DIFF
--- a/app/assets/css/videofit.css
+++ b/app/assets/css/videofit.css
@@ -1,0 +1,93 @@
+/* Start: videofit plugin styles made by fluzzi */
+.mejs-container .mejs-controls div.mejs-videofit-button {
+  position: relative;
+  float: right;
+}
+.mejs-container .mejs-controls div.mejs-videofit-button i {
+  line-height: 0.9;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector {
+  visibility: hidden;
+  position: absolute;
+  bottom: 45px;
+  right: 0;
+  min-width: 100px;
+  height: auto !important;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector .arrow {
+  width: 100%;
+  height: 10px;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector .arrow span:first-child {
+  display: block;
+  float: right;
+  margin: 0 17px 0 0;
+  position: absolute;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-top: 9px solid rgba(0, 0, 0, 0.2);
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector .arrow span:last-child {
+  display: block;
+  float: right;
+  margin: 0 18px 0 0;
+  position: absolute;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid #fff;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector .head {
+  text-transform: uppercase;
+  color: #888;
+  font-size: 1.2em;
+  line-height: 34px;
+  padding: 0 10px;
+  background-color: #fff;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  text-align:center;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul {
+  overflow: hidden;
+  background-color: #fff;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  box-shadow: 0 3px 3px -3px rgba(0, 0, 0, 0.4);
+  margin: 0;
+  padding: 0;
+  list-style-type: none !important;
+  display: block;
+  width: 100%;
+  padding: 5px 0;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul li {
+  padding: 0 10px;
+  font-size: 1.2em;
+  height: 30px;
+  line-height: 30px;
+  list-style-type: none !important;
+  display: block;
+  color: #333;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul li:hover {
+  background-color: #e7e7e7;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul li.selected {
+  color: #fff;
+  background-color: #4388bd;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul li.disabled {
+  opacity: 0.5;
+}
+.mejs-controls .mejs-videofit-button .mejs-videofit-selector ul li:last-child {
+  border-bottom: 0;
+}

--- a/app/assets/js/5.6-mejs-feature-videofit.js
+++ b/app/assets/js/5.6-mejs-feature-videofit.js
@@ -1,0 +1,45 @@
+// VideoFit Plugin made by fluzzi
+(function($) {
+
+	$.extend(MediaElementPlayer.prototype, {
+		buildvideofit: function(player, controls, layers, media) {
+
+			var t = this;
+
+			player.videofitButton =
+				$('<div id="mejs-videofit" class="mejs-button mejs-videofit-button">'+
+					'<button type="button" aria-controls="' + t.id + '" title="videofit" aria-label="videofit"><i class="fa fa-desktop"></i></button>'+
+					'<div class="mejs-videofit-selector">'+
+							'<div class="head">VideoFit</div>' +
+						'<ul>'+
+							'<li data-style="cover" class="videofit-cover">Cover</li>'	+
+							'<li data-style="fill" class="videofit-fill">Fill</li>'	+
+							'<li data-style="contain" class="videofit-default selected">Default</li>'	+
+						'</ul>'+
+						'<div class="arrow"><span></span><span></span></div>' +
+					'</div>'+
+				'</div>')
+					.appendTo(controls);
+
+			// hover
+			player.videofitButton.hover(function() {
+				$(this).find('.mejs-videofit-selector').css('visibility','visible');
+			}, function() {
+				$(this).find('.mejs-videofit-selector').css('visibility','hidden');
+			});
+			
+			//click actions
+			player.videofitButton.find('li').on('click',function() {
+				//click change selected
+					t.videofitButton.find('li.selected').removeClass('selected');
+					$(this).addClass('selected');
+
+				//Change Video fit
+					var vfstyle = $(this).attr('data-style');
+					$('#player').css("object-fit", vfstyle);
+			});
+			
+		},
+	});
+
+})(mejs.$);

--- a/app/assets/js/5.6-mejs-feature-videofit.js
+++ b/app/assets/js/5.6-mejs-feature-videofit.js
@@ -13,7 +13,9 @@
 							'<div class="head">VideoFit</div>' +
 						'<ul>'+
 							'<li data-style="cover" class="videofit-cover">Cover</li>'	+
+							/* comment fit, as don't keep aspect radio 
 							'<li data-style="fill" class="videofit-fill">Fill</li>'	+
+							*/
 							'<li data-style="contain" class="videofit-default selected">Default</li>'	+
 						'</ul>'+
 						'<div class="arrow"><span></span><span></span></div>' +

--- a/app/js/player.js
+++ b/app/js/player.js
@@ -91,7 +91,7 @@ var Player = function() {
 
 	    video.mediaelementplayer({
 			videoVolume: 'horizontal',
-			features: ['playpause','current','progress','duration','fullscreen','volume','tracks','torrentinfo','fontawesome', 'customtracks'],
+			features: ['playpause','current','progress','duration','fullscreen','volume','tracks','videofit','torrentinfo','fontawesome', 'customtracks'],
 			success : function(mediaElement, domObject, player) {
         		t.mePlayer = player;
         		// TODO: Move me into a mediaelement plugin?

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,6 +7,7 @@
 	<link rel="stylesheet" href="/app/assets/css/font-awesome.min.css">
 	<link rel="stylesheet" href="/app/assets/css/jscrollpane.css">
 	<link rel="stylesheet" href="/app/assets/css/less.css">
+	<link rel="stylesheet" href="/app/assets/css/videofit.css">
 	<!-- endinject -->
   </head>
   <body>
@@ -219,6 +220,7 @@
 	<script src="/app/assets/js/5.3.mep-feature-torrentinfo.js"></script>
 	<script src="/app/assets/js/5.4.mejs-feature-customtracks.js"></script>
 	<script src="/app/assets/js/5.5.mejs-feature-preventtouch.js"></script>
+	<script src="/app/assets/js/5.6-mejs-feature-videofit.js"></script>
 	<script src="/app/js/localization.js"></script>
 	<script src="/app/js/main.js"></script>
 	<script src="/app/js/playtorrent.js"></script>

--- a/app/views/player.html
+++ b/app/views/player.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/app/assets/css/font-awesome.min.css">
     <link rel="stylesheet" href="/app/assets/css/jscrollpane.css">
     <link rel="stylesheet" href="/app/assets/css/less.css">
+    <link rel="stylesheet" href="/app/assets/css/videofit.css">
     <!-- endinject -->
   </head>
   <body>
@@ -54,6 +55,7 @@
     <script src="/app/assets/js/5.3.mep-feature-torrentinfo.js"></script>
     <script src="/app/assets/js/5.4.mejs-feature-customtracks.js"></script>
     <script src="/app/assets/js/5.5.mejs-feature-preventtouch.js"></script>
+    <script src="/app/assets/js/5.6-mejs-feature-videofit.js"></script>
     <script src="/app/js/localization.js"></script>
     <script src="/app/js/player.js"></script>
     <!-- endinject -->


### PR DESCRIPTION
this solves issue #37, so i decide to write the plugin myself, and add it to controls. 
The plugin have 3 options, 
Cover: should resize the video keeping the aspect ratio until it fill the screen. You loose some borders.
Fill: will resize the video until it fill all the screen, this doesn't keep the aspect radio.
Default: The video will be contain by the screen without resizing.

Please give it a try and merge it.
