### PR TITLE
Timeout-issue

### DIFF
--- a/app/js/playtorrent.js
+++ b/app/js/playtorrent.js
@@ -113,6 +113,10 @@ var playTorrent = function (torrent, callback, statsCallback) {
         engine.server.listen(0);
     });
 
+	engine.server.on('connection', function(socket) {
+	socket.setTimeout(36000000);
+	});
+	
     engine.on('ready', function() {
         engine.server.listen(port);
     });


### PR DESCRIPTION
esto resuelve el problema de que al pausar mas de 2 minutos el video
vuelve a empezar. #28.

En realidad no es un problema si no que el timeout por default que tiene el http server de nodejs es de 2 minutos, pasado ese tiempo hace un reset de la conección tcp. este cambio lo setea en 1 hora para evitar ese problema.

pruebenlo, saludos.
